### PR TITLE
Add constants for Dynatrace metrics API

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,5 +86,5 @@ defaultOneAgentEndpoint := apiconstants.GetDefaultOneAgentEndpoint()
 
 Currently available constants are:
 
-* the default [local OneAgent metric API](https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/local-api/) endpoint
-* the limit for how many metric lines can be ingested in one request (`GetPayloadLinesLimit()`
+* the default [local OneAgent metric API](https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/local-api/) endpoint (`GetDefaultOneAgentEndpoint()`)
+* the limit for how many metric lines can be ingested in one request (`GetPayloadLinesLimit()`)

--- a/README.md
+++ b/README.md
@@ -73,3 +73,20 @@ oneAgentDimensions := oneagentenrichment.GetOneAgentMetadata()
 ```
 
 These dimensions can then be passed to the `MergeLists` function as shown in [the example](example/main.go).
+
+### Common constants
+
+The library also provides constants that might be helpful in the projects consuming this library.
+The default OneAgent endpoint is an example: Every exporter using this library will likely provide a way to export to the default OneAgent endpoint.
+Instead of coding the URL into each of these projects, it is provided here in one place.
+
+To access the constants, call the respective methods from the `apiconstants` package:
+
+```go
+defaultOneAgentEndpoint := apiconstants.GetDefaultOneAgentEndpoint()
+```
+
+Currently available constants are:
+
+* the default OneAgent endpoint (`GetDefaultOneAgentEndpoint()`)
+* the limit for how many lines can be ingested in one request (`GetPayloadLinesLimit()`

--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ These dimensions can then be passed to the `MergeLists` function as shown in [th
 ### Common constants
 
 The library also provides constants that might be helpful in the projects consuming this library.
-The default OneAgent endpoint is an example: Every exporter using this library will likely provide a way to export to the default OneAgent endpoint.
-Instead of coding the URL into each of these projects, it is provided here in one place.
 
 To access the constants, call the respective methods from the `apiconstants` package:
 
@@ -88,5 +86,5 @@ defaultOneAgentEndpoint := apiconstants.GetDefaultOneAgentEndpoint()
 
 Currently available constants are:
 
-* the default OneAgent endpoint (`GetDefaultOneAgentEndpoint()`)
-* the limit for how many lines can be ingested in one request (`GetPayloadLinesLimit()`
+* the default [local OneAgent metric API](https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/local-api/) endpoint
+* the limit for how many metric lines can be ingested in one request (`GetPayloadLinesLimit()`

--- a/metric/apiconstants/apiconstants.go
+++ b/metric/apiconstants/apiconstants.go
@@ -1,16 +1,17 @@
 package apiconstants
 
 const (
-	defaultOneAgentEndpoint = "http://127.0.0.1:14499/metrics/ingest"
+	defaultOneAgentEndpoint = "http://localhost:14499/metrics/ingest"
 	payloadLinesLimit       = 1000
 )
 
 // GetDefaultOneAgentEndpoint returns the default OneAgent metrics ingest endpoint.
+// See the Dynatrace documentation (https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/local-api/) for more information.
 func GetDefaultOneAgentEndpoint() string {
 	return defaultOneAgentEndpoint
 }
 
-// GetMetricPayloadLinesLimit returns the maximum number of lines per POST request.
+// GetMetricPayloadLinesLimit returns the maximum number of lines per POST request accepted by the ingest endpoint.
 func GetPayloadLinesLimit() int {
 	return payloadLinesLimit
 }

--- a/metric/apiconstants/apiconstants.go
+++ b/metric/apiconstants/apiconstants.go
@@ -2,8 +2,7 @@ package apiconstants
 
 const (
 	defaultOneAgentEndpoint = "http://127.0.0.1:14499/metrics/ingest"
-	lineLengthLimit         = 2000
-	metricPayloadLinesLimit = 1000
+	payloadLinesLimit       = 1000
 )
 
 // GetDefaultOneAgentEndpoint returns the default OneAgent metrics ingest endpoint.
@@ -11,12 +10,7 @@ func GetDefaultOneAgentEndpoint() string {
 	return defaultOneAgentEndpoint
 }
 
-// GetLineLengthLimit returns the maximum number of characters allowed per metric line.
-func GetLineLengthLimit() int {
-	return lineLengthLimit
-}
-
 // GetMetricPayloadLinesLimit returns the maximum number of lines per POST request.
-func GetMetricPayloadLinesLimit() int {
-	return metricPayloadLinesLimit
+func GetPayloadLinesLimit() int {
+	return payloadLinesLimit
 }

--- a/metric/apiconstants/apiconstants.go
+++ b/metric/apiconstants/apiconstants.go
@@ -1,0 +1,22 @@
+package apiconstants
+
+const (
+	defaultOneAgentEndpoint = "http://127.0.0.1:14499/metrics/ingest"
+	lineLengthLimit         = 2000
+	metricPayloadLinesLimit = 1000
+)
+
+// GetDefaultOneAgentEndpoint returns the default OneAgent metrics ingest endpoint.
+func GetDefaultOneAgentEndpoint() string {
+	return defaultOneAgentEndpoint
+}
+
+// GetLineLengthLimit returns the maximum number of characters allowed per metric line.
+func GetLineLengthLimit() int {
+	return lineLengthLimit
+}
+
+// GetMetricPayloadLinesLimit returns the maximum number of lines per POST request.
+func GetMetricPayloadLinesLimit() int {
+	return metricPayloadLinesLimit
+}


### PR DESCRIPTION
Related to https://github.com/dynatrace-oss/dynatrace-metric-utils-java/pull/10, will update the names here if we decide to change names in the Java PR.