### PR TITLE
Ensure dimension value stays within length limit after escaping

### DIFF
--- a/normalize/dimensionvalue.go
+++ b/normalize/dimensionvalue.go
@@ -19,10 +19,11 @@ import (
 )
 
 var (
-	reDvControlCharacters      = regexp.MustCompile("\\p{C}+")
-	reDvControlCharactersStart = regexp.MustCompile("^\\p{C}+")
-	reDvControlCharactersEnd   = regexp.MustCompile("\\p{C}+$")
-	reDvToEscapeCharacters     = regexp.MustCompile(`([= ,\\"])`)
+	reDvControlCharacters                 = regexp.MustCompile("\\p{C}+")
+	reDvControlCharactersStart            = regexp.MustCompile("^\\p{C}+")
+	reDvControlCharactersEnd              = regexp.MustCompile("\\p{C}+$")
+	reDvToEscapeCharacters                = regexp.MustCompile(`([= ,\\"])`)
+	reDvHasOddNumberOfTrailingBackslashes = regexp.MustCompile(`[^\\](?:\\\\)*\\$`)
 )
 
 const (
@@ -50,5 +51,14 @@ func removeControlCharacters(s string) string {
 }
 
 func escapeCharacters(s string) string {
-	return reDvToEscapeCharacters.ReplaceAllString(s, "\\$1")
+	escaped := reDvToEscapeCharacters.ReplaceAllString(s, "\\$1")
+	if len(escaped) > dimensionValueMaxLength {
+		escaped = escaped[:dimensionValueMaxLength]
+
+		if reDvHasOddNumberOfTrailingBackslashes.MatchString(escaped) {
+			escaped = escaped[:dimensionValueMaxLength-1]
+		}
+	}
+
+	return escaped
 }

--- a/normalize/dimensionvalue_test.go
+++ b/normalize/dimensionvalue_test.go
@@ -76,12 +76,17 @@ func TestDimensionValue(t *testing.T) {
 			want: "a\\\\b",
 		},
 		{
-			name: "escape multiple invalids",
+			name: "escape multiple special chars",
 			args: args{value: " ,=\\"},
 			want: "\\ \\,\\=\\\\",
 		},
 		{
-			name: "escape quoted multiple invalids",
+			name: "escape consecutive special chars",
+			args: args{value: "  ,,==\\\\"},
+			want: "\\ \\ \\,\\,\\=\\=\\\\\\\\",
+		},
+		{
+			name: "escape quoted multiple special chars",
 			args: args{value: `"\ ""`},
 			want: `\"\\\ \"\"`,
 		},
@@ -154,6 +159,28 @@ func TestDimensionValue(t *testing.T) {
 			name: "invalid truncate value too long",
 			args: args{value: strings.Repeat("a", 270)},
 			want: strings.Repeat("a", 250),
+		},
+		{
+			name: "escape sequence not broken apart 1",
+			args: args{value: strings.Repeat("a", 249) + "="},
+			want: strings.Repeat("a", 249),
+		},
+		{
+			name: "escape sequence not broken apart 2",
+			args: args{value: strings.Repeat("a", 248) + "=="},
+			want: strings.Repeat("a", 248) + "\\=",
+		},
+		{
+			name: "escape sequence not broken apart 3",
+			// 3 trailing backslashes before escaping
+			args: args{value: strings.Repeat("a", 247) + "\\\\\\"},
+			// 1 escaped trailing backslash
+			want: strings.Repeat("a", 247) + "\\\\",
+		},
+		{
+			name: "dimension value of only backslashes",
+			args: args{value: strings.Repeat("\\", 270)},
+			want: strings.Repeat("\\\\", 125),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Very similar to https://github.com/dynatrace-oss/dynatrace-metric-utils-java/pull/11, except we don't have to change code to ensure values are not escaped twice. As far as i can tell, there is no way to actually pass the same dimension to the normalize function twice, as the dimensions become inaccessible as soon as they are normalized.